### PR TITLE
Fix Promises being incorrectly rejected

### DIFF
--- a/lib/leek.js
+++ b/lib/leek.js
@@ -43,7 +43,10 @@ Leek.prototype._enqueue = function(eventType, meta) {
     );
     return request(
       params,
-      reject
+      function(err, res, body) {
+        if (err) return reject(err);
+        resolve();
+      }
     );
   }.bind(this));
 };


### PR DESCRIPTION
Returned Promises were being incorrectly rejected regardless of whether request() returned an error. FWIW, this suggests to me that your tests aren't checking your return values or their resolution.
